### PR TITLE
Dennis fix race

### DIFF
--- a/fairmq/FairMQDevice.cxx
+++ b/fairmq/FairMQDevice.cxx
@@ -24,6 +24,7 @@
 #include <functional>
 #include <sstream>
 #include <iomanip>
+#include <future>
 #include <algorithm> // std::max
 
 using namespace std;
@@ -491,7 +492,7 @@ void FairMQDevice::RunWrapper()
     LOG(info) << "DEVICE: Running...";
 
     // start the rate logger thread
-    thread rateLogger(&FairMQDevice::LogSocketRates, this);
+    future<void> rateLogger = async(launch::async, &FairMQDevice::LogSocketRates, this);
 
     // notify transports to resume transfers
     {
@@ -552,7 +553,7 @@ void FairMQDevice::RunWrapper()
 
     CallAndHandleError(std::bind(&FairMQDevice::PostRun, this));
 
-    rateLogger.join();
+    rateLogger.get();
 }
 
 void FairMQDevice::HandleSingleChannelInput()

--- a/fairmq/plugins/Control.cxx
+++ b/fairmq/plugins/Control.cxx
@@ -209,6 +209,11 @@ try
             }
         }
 
+        if (GetCurrentDeviceState() == DeviceState::Error)
+        {
+            throw DeviceErrorState("Controlled device transitioned to error state.");
+        }
+
         if (fDeviceShutdownRequested)
         {
             break;
@@ -272,6 +277,11 @@ try
         while (fEvents.empty() && !fDeviceShutdownRequested)
         {
             fNewEvent.wait_for(lock, chrono::milliseconds(50));
+        }
+
+        if (fEvents.front() == DeviceState::Error)
+        {
+            throw DeviceErrorState("Controlled device transitioned to error state.");
         }
     }
 


### PR DESCRIPTION
- Use future instead of thread for device rateLogger
- Handle errors in static and interactive controllers
---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
